### PR TITLE
エラーハンドリング更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,13 +235,13 @@ console.log (ccxt.exchanges) // print all available exchanges
 
 All-in-one browser bundle (dependencies included), served from a CDN of your choice:
 
-* jsDelivr: https://cdn.jsdelivr.net/npm/ccxt@1.42.29/dist/ccxt.browser.js
-* unpkg: https://unpkg.com/ccxt@1.42.29/dist/ccxt.browser.js
+* jsDelivr: https://cdn.jsdelivr.net/npm/ccxt@1.42.30/dist/ccxt.browser.js
+* unpkg: https://unpkg.com/ccxt@1.42.30/dist/ccxt.browser.js
 
 CDNs are not updated in real-time and may have delays. Defaulting to the most recent version without specifying the version number is not recommended. Please, keep in mind that we are not responsible for the correct operation of those CDN servers.
 
 ```HTML
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/ccxt@1.42.29/dist/ccxt.browser.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/ccxt@1.42.30/dist/ccxt.browser.js"></script>
 ```
 
 Creates a global `ccxt` object:

--- a/ccxt.d.ts
+++ b/ccxt.d.ts
@@ -28,8 +28,6 @@ declare module '@ango-ya/ccxt' {
     export class InvalidAddress extends ExchangeError {}
     export class AddressPending extends InvalidAddress {}
     export class InvalidOrder extends ExchangeError {}
-    export class InvalidRangeOrder extends ExchangeError {}
-    export class InvalidUsdOrder extends ExchangeError {}
     export class OrderNotFound extends InvalidOrder {}
     export class OrderNotCached extends InvalidOrder {}
     export class CancelPending extends InvalidOrder {}

--- a/ccxt.d.ts
+++ b/ccxt.d.ts
@@ -28,6 +28,8 @@ declare module '@ango-ya/ccxt' {
     export class InvalidAddress extends ExchangeError {}
     export class AddressPending extends InvalidAddress {}
     export class InvalidOrder extends ExchangeError {}
+    export class InvalidRangeOrder extends ExchangeError {}
+    export class InvalidUsdOrder extends ExchangeError {}
     export class OrderNotFound extends InvalidOrder {}
     export class OrderNotCached extends InvalidOrder {}
     export class CancelPending extends InvalidOrder {}

--- a/ccxt.js
+++ b/ccxt.js
@@ -35,7 +35,7 @@ const Exchange  = require ('./js/base/Exchange')
 //-----------------------------------------------------------------------------
 // this is updated by vss.js when building
 
-const version = '1.42.29'
+const version = '1.42.30'
 
 Exchange.ccxtVersion = version
 

--- a/js/base/errorHierarchy.js
+++ b/js/base/errorHierarchy.js
@@ -28,6 +28,8 @@ const errorHierarchy = {
                 'OrderImmediatelyFillable': {},
                 'OrderNotFillable': {},
                 'DuplicateOrderId': {},
+                'InvalidUsdOrder': {},
+                'InvalidRangeOrder': {},
             },
             'NotSupported': {},
         },

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -3,7 +3,7 @@
 //  ---------------------------------------------------------------------------
 
 const Exchange = require ('./base/Exchange');
-const { ExchangeError, ExchangeNotAvailable, OnMaintenance, ArgumentsRequired, BadRequest, AccountSuspended, InvalidAddress, PermissionDenied, DDoSProtection, InsufficientFunds, InvalidNonce, CancelPending, InvalidOrder, OrderNotFound, AuthenticationError, RequestTimeout, BadSymbol, RateLimitExceeded } = require ('./base/errors');
+const { ExchangeError, ExchangeNotAvailable, OnMaintenance, ArgumentsRequired, BadRequest, AccountSuspended, InvalidAddress, PermissionDenied, DDoSProtection, InsufficientFunds, InvalidNonce, CancelPending, InvalidOrder, InvalidUsdOrder, InvalidRangeOrder, OrderNotFound, AuthenticationError, RequestTimeout, BadSymbol, RateLimitExceeded } = require ('./base/errors');
 const { TICK_SIZE } = require ('./base/functions/number');
 const Precise = require ('./base/Precise');
 
@@ -667,6 +667,11 @@ module.exports = class bitget extends Exchange {
                     '40712': InsufficientFunds, // Insufficient margin
                     '40713': ExchangeError, // Cannot exceed the maximum transferable margin amount
                     '40714': ExchangeError, // No direct margin call is allowed
+                    '43006': InvalidOrder,
+                    '43008': InvalidRangeOrder,
+                    '43009': InvalidRangeOrder,
+                    '43012': InvalidOrder,
+                    '45110': InvalidUsdOrder,
                     // spot
                     'invalid sign': AuthenticationError,
                     'invalid currency': BadSymbol, // invalid trading pair

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -668,8 +668,8 @@ module.exports = class bitget extends Exchange {
                     '40713': ExchangeError, // Cannot exceed the maximum transferable margin amount
                     '40714': ExchangeError, // No direct margin call is allowed
                     '43006': InvalidOrder,
-                    '43008': InvalidRangeOrder,
-                    '43009': InvalidRangeOrder,
+                    '43008': InvalidRangeOrder, // in sell Order
+                    '43009': InvalidRangeOrder, // in buy Order
                     '43012': InvalidOrder,
                     '45110': InvalidUsdOrder,
                     // spot

--- a/js/bittrex.js
+++ b/js/bittrex.js
@@ -204,7 +204,7 @@ module.exports = class bittrex extends Exchange {
                     'APIKEY_INVALID': AuthenticationError,
                     'INVALID_SIGNATURE': AuthenticationError,
                     'INVALID_CURRENCY': ExchangeError,
-                    'INVALID_PERMISSION': AuthenticationError,
+                    'INVALID_PERMISSION': PermissionDenied,
                     'INSUFFICIENT_FUNDS': InsufficientFunds,
                     'INVALID_CEILING_MARKET_BUY': InvalidOrder,
                     'INVALID_FIAT_ACCOUNT': InvalidOrder,

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -243,6 +243,8 @@ module.exports = class poloniex extends Exchange {
                     'This account is closed.': AccountSuspended, // {"error":"This account is closed."}
                 },
                 'broad': {
+                    'Failed to place a new order: Amount scale error': InvalidOrder,
+                    'Account is disabled for trading. Please contact support.': PermissionDenied,
                     'Total must be at least': InvalidOrder, // {"error":"Total must be at least 0.0001."}
                     'This account is frozen': AccountSuspended, // {"error":"This account is frozen for trading."} || {"error":"This account is frozen."}
                     'This account is locked.': AccountSuspended, // {"error":"This account is locked."}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ango-ya/ccxt",
-  "version": "1.42.27",
+  "version": "1.42.30",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ango-ya/ccxt",
-      "version": "1.42.27",
+      "version": "1.42.30",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ango-ya/ccxt",
-  "version": "1.42.29",
+  "version": "1.42.30",
   "description": "A JavaScript / Python / PHP cryptocurrency trading library with support for 130+ exchanges",
   "main": "./ccxt.js",
   "unpkg": "dist/ccxt.browser.js",

--- a/wiki/Install.md
+++ b/wiki/Install.md
@@ -58,13 +58,13 @@ If that does not help, please, follow here: https://github.com/nodejs/node-gyp#o
 
 All-in-one browser bundle (dependencies included), served from a CDN of your choice:
 
-* jsDelivr: https://cdn.jsdelivr.net/npm/ccxt@1.42.29/dist/ccxt.browser.js
-* unpkg: https://unpkg.com/ccxt@1.42.29/dist/ccxt.browser.js
+* jsDelivr: https://cdn.jsdelivr.net/npm/ccxt@1.42.30/dist/ccxt.browser.js
+* unpkg: https://unpkg.com/ccxt@1.42.30/dist/ccxt.browser.js
 
 You can obtain a live-updated version of the bundle by removing the version number from the URL (the `@a.b.c` thing) — however, we do not recommend to do that, as it may break your app eventually. Also, please keep in mind that we are not responsible for the correct operation of those CDN servers.
 
 ```HTML
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/ccxt@1.42.29/dist/ccxt.browser.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/ccxt@1.42.30/dist/ccxt.browser.js"></script>
 ```
 
 Creates a global `ccxt` object:


### PR DESCRIPTION
エラーを `ExchangeError` で判断するとバグが起きる（例. 価格乖離エラーをAPI権限エラーとして判断する）ことがあるので、使わないようにする。
その他エラーも使いやすいようにする。

**Bittrex**
・取引権限エラーを `PermissionDenied` にする（今までのChojaと同じ）。

**Poloniex**
・取引権限エラーを `PermissionDenied` にする
・一部の最低取引高エラーを `InvalidOrder` にする

**Bitget**
・取引高エラーを `InvalidOrder` にする
・価格乖離エラーを `InvalidRangeOrder` にする
・ドル建てエラーを `InvalidUsdOrder` にする