### PR TITLE
注文量0の時のエラーも追加

### DIFF
--- a/js/bitget.js
+++ b/js/bitget.js
@@ -667,10 +667,11 @@ module.exports = class bitget extends Exchange {
                     '40712': InsufficientFunds, // Insufficient margin
                     '40713': ExchangeError, // Cannot exceed the maximum transferable margin amount
                     '40714': ExchangeError, // No direct margin call is allowed
-                    '43006': InvalidOrder,
+                    '40808': InvalidOrder, //  Amount 0
+                    '43006': InvalidOrder, // in limit and market sell Order
                     '43008': InvalidRangeOrder, // in sell Order
                     '43009': InvalidRangeOrder, // in buy Order
-                    '43012': InvalidOrder,
+                    '43012': InvalidOrder, // in market buy Order
                     '45110': InvalidUsdOrder,
                     // spot
                     'invalid sign': AuthenticationError,

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -246,6 +246,7 @@ module.exports = class poloniex extends Exchange {
                     'Failed to place a new order: Amount scale error': InvalidOrder,
                     'Account is disabled for trading. Please contact support.': PermissionDenied,
                     'Total must be at least': InvalidOrder, // {"error":"Total must be at least 0.0001."}
+                    'Quantity must greater than zero': InvalidOrder,
                     'This account is frozen': AccountSuspended, // {"error":"This account is frozen for trading."} || {"error":"This account is frozen."}
                     'This account is locked.': AccountSuspended, // {"error":"This account is locked."}
                     'Not enough': InsufficientFunds,


### PR DESCRIPTION
注文量が足りないケースは、以下の①だけでなく②も考えられるので、注文量0の時のエラーインスタンスを修正しました。
①注文量が最低取引高以下（例：0.0000001BTC）
②注文量0になる

※ Bittrexはccxtで対応できなさそうだったので、chojaで対応します。
※ このリポジトリのビルド作業やバージョンアップは、PRに入れるとレビュワーが分かりにくいので、PRでapproveいただいてからやります。