### PR TITLE
poloniexで通貨シンボルを変える

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -1166,9 +1166,16 @@ module.exports = class poloniex extends Exchange {
         const upperCaseType = type.toUpperCase ();
         const isMarket = upperCaseType === 'MARKET';
         if (isMarket) {
+            const checkSwitchPair = (currencySymbol) => {
+              if(currencySymbol === "XLM"){
+                return "STR"
+              }
+              return currencySymbol
+            }
+            const pairSymbol = checkSwitchPair(market['base']) + '_' + market['quote'];
             method = 'privatePostOrders';
             request = {
-                'symbol': market['base'] + '_' + market['quote'],
+                'symbol': pairSymbol,
                 'side': side,
                 'type': upperCaseType,
             };


### PR DESCRIPTION
## Why
・poloniexで、API仕様の変更により`XLM`（STR）の成行注文が出せない。原因は成行注文ではシンボル名`XLM`を`STR`に変更する必要があるが、その処理がccxtにはない
https://ango-ya.slack.com/archives/C01DBHW3326/p1674178644294649

## やったこと
・成行注文ではシンボル名`XLM`を`STR`に変更する