### PR TITLE
通貨名STRで注文できるようにする

### DIFF
--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -1160,7 +1160,15 @@ module.exports = class poloniex extends Exchange {
          */
         await this.loadMarkets ();
         let method = 'privatePost' + this.capitalize (side);
-        const market = this.market (symbol);
+        const checkSwitchPair = (pairSymbol) => {
+            const includeSTR = /^STR\//;
+            if (includeSTR.test(pairSymbol)) {
+                return pairSymbol.replace('STR', 'XLM');
+            };
+            return pairSymbol;
+        };
+        const pairSymbol = checkSwitchPair (symbol);
+        const market = this.market (pairSymbol);
         amount = this.amountToPrecision (symbol, amount);
         let request = {};
         const upperCaseType = type.toUpperCase ();
@@ -1172,22 +1180,22 @@ module.exports = class poloniex extends Exchange {
                 }
                 return currencySymbol;
             };
-            const pairSymbol = checkSwitchPair (market['base']) + '_' + market['quote'];
+            const marketPairSymbol = checkSwitchPair (market['base']) + '_' + market['quote'];
             method = 'privatePostOrders';
             request = {
-                'symbol': pairSymbol,
+                'symbol': marketPairSymbol,
                 'side': side,
                 'type': upperCaseType,
             };
             if (side === 'buy') {
                 request['amount'] = this.currencyToPrecision (market['quote'], amount);
             } else {
-                request['quantity'] = this.amountToPrecision (symbol, amount);
+                request['quantity'] = this.amountToPrecision (pairSymbol, amount);
             }
         } else {
             request = {
                 'currencyPair': market['id'],
-                'rate': this.priceToPrecision (symbol, price),
+                'rate': this.priceToPrecision (pairSymbol, price),
                 'amount': amount,
             };
         }

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -1169,7 +1169,7 @@ module.exports = class poloniex extends Exchange {
         };
         const pairSymbol = checkSwitchPair (symbol);
         const market = this.market (pairSymbol);
-        amount = this.amountToPrecision (symbol, amount);
+        amount = this.amountToPrecision (pairSymbol, amount);
         let request = {};
         const upperCaseType = type.toUpperCase ();
         const isMarket = upperCaseType === 'MARKET';

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -1174,13 +1174,13 @@ module.exports = class poloniex extends Exchange {
         const upperCaseType = type.toUpperCase ();
         const isMarket = upperCaseType === 'MARKET';
         if (isMarket) {
-            const checkSwitchPair = (currencySymbol) => {
+            const checkSwitchCurrency = (currencySymbol) => {
                 if (currencySymbol === 'XLM') {
                     return 'STR';
                 }
                 return currencySymbol;
             };
-            const marketPairSymbol = checkSwitchPair (market['base']) + '_' + market['quote'];
+            const marketPairSymbol = checkSwitchCurrency (market['base']) + '_' + market['quote'];
             method = 'privatePostOrders';
             request = {
                 'symbol': marketPairSymbol,

--- a/js/poloniex.js
+++ b/js/poloniex.js
@@ -1159,7 +1159,8 @@ module.exports = class poloniex extends Exchange {
          * @returns {object} an [order structure]{@link https://docs.ccxt.com/en/latest/manual.html#order-structure}
          */
         await this.loadMarkets ();
-        let method = 'privatePost' + this.capitalize (side);
+        let method = 'privatePost' + this.capitalize(side);
+        // Symbols on poloniex UI are STR, but market functions need to use XLM
         const checkSwitchPair = (pairSymbol) => {
             const includeSTR = /^STR\//;
             if (includeSTR.test(pairSymbol)) {
@@ -1174,6 +1175,7 @@ module.exports = class poloniex extends Exchange {
         const upperCaseType = type.toUpperCase ();
         const isMarket = upperCaseType === 'MARKET';
         if (isMarket) {
+            // XLM cannot be used in a market order, so XLM once converted from STR is converted back to STR and used again.
             const checkSwitchCurrency = (currencySymbol) => {
                 if (currencySymbol === 'XLM') {
                     return 'STR';
@@ -1190,11 +1192,13 @@ module.exports = class poloniex extends Exchange {
             if (side === 'buy') {
                 request['amount'] = this.currencyToPrecision (market['quote'], amount);
             } else {
+                // STR is not available in amountToPrecision, so use XLM as it is.
                 request['quantity'] = this.amountToPrecision (pairSymbol, amount);
             }
         } else {
             request = {
                 'currencyPair': market['id'],
+                // STR is not available in amountToPrecision, so use XLM as it is.
                 'rate': this.priceToPrecision (pairSymbol, price),
                 'amount': amount,
             };


### PR DESCRIPTION
こちらの追加変更
https://github.com/ango-ya/ccxt/pull/16

## Why
poloniexで利用するシンボルを`STR`とした。
STRでは、createOrdernaiのmarket関数を利用できない。

## やったこと
・STRでは、createOrdernaiのmarket関数を利用できないため、利用できるようにした。
・変数名を一部変更した