### PR TITLE
キャッシュしたマーケットデータを利用できるようにする

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,13 +238,13 @@ console.log (ccxt.exchanges) // print all available exchanges
 
 All-in-one browser bundle (dependencies included), served from a CDN of your choice:
 
-* jsDelivr: https://cdn.jsdelivr.net/npm/ccxt@1.50.1/dist/ccxt.browser.js
-* unpkg: https://unpkg.com/ccxt@1.50.1/dist/ccxt.browser.js
+* jsDelivr: https://cdn.jsdelivr.net/npm/ccxt@1.50.2/dist/ccxt.browser.js
+* unpkg: https://unpkg.com/ccxt@1.50.2/dist/ccxt.browser.js
 
 CDNs are not updated in real-time and may have delays. Defaulting to the most recent version without specifying the version number is not recommended. Please, keep in mind that we are not responsible for the correct operation of those CDN servers.
 
 ```HTML
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/ccxt@1.50.1/dist/ccxt.browser.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/ccxt@1.50.2/dist/ccxt.browser.js"></script>
 ```
 
 Creates a global `ccxt` object:

--- a/ccxt.d.ts
+++ b/ccxt.d.ts
@@ -425,8 +425,7 @@ declare module '@ango-ya/ccxt' {
         YmdHMS (timestamp: string, infix: string) : string;
 	      resetBalance (currencies: string): Promise<any>; // 引数の例） "BTC,ETH,ADAB"
         sendBalance (toAccount: number, currency: string, amount: string): Promise<any>;
-        callCoinList(data: string): Promise<void>;
-        getCoinList(): Promise<string>;
+        callMarkets(coinListData: string, marketData?: string): Promise<void>;
     }
 
     /* tslint:disable */

--- a/ccxt.js
+++ b/ccxt.js
@@ -35,7 +35,7 @@ const Exchange  = require ('./js/base/Exchange')
 //-----------------------------------------------------------------------------
 // this is updated by vss.js when building
 
-const version = '1.50.1'
+const version = '1.50.2'
 
 Exchange.ccxtVersion = version
 

--- a/js/base/Exchange.js
+++ b/js/base/Exchange.js
@@ -611,7 +611,7 @@ module.exports = class Exchange {
         return this.quoteJsonNumbers ? responseBody.replace (/":([+.0-9eE-]+)([,}])/g, '":"$1"$2') : responseBody;
     }
 
-    async loadMarketsHelper (data = undefined, reload = false, params = {}) {
+    async loadMarketsHelper (coinListData = undefined, marketData = undefined ,reload = false, params = {}) {
         if (!reload && this.markets) {
             if (!this.markets_by_id) {
                 return this.setMarkets (this.markets)
@@ -621,13 +621,19 @@ module.exports = class Exchange {
         let currencies = undefined
         // only call if exchange API provides endpoint (true), thus avoid emulated versions ('emulated')
         if (this.has.fetchCurrencies === true) {
-            if (data) {
-                currencies = data
+            if (coinListData) {
+                currencies = coinListData
             } else {
                 currencies = await this.fetchCurrencies ()
             }
         }
-        const markets = await this.fetchMarkets (params)
+
+        let markets = undefined
+        if (marketData) {
+          markets = marketData
+        } else {
+          markets = await this.fetchMarkets (params)
+        }
         return this.setMarkets (markets, currencies)
     }
 
@@ -654,11 +660,11 @@ module.exports = class Exchange {
         return networkCode;
     }
 
-    loadMarkets (data = undefined, reload = false, params = {}) {
+    loadMarkets (coinListData = undefined, marketData = undefined, reload = false, params = {}) {
         // this method is async, it returns a promise
         if ((reload && !this.reloadingMarkets) || !this.marketsLoading) {
             this.reloadingMarkets = true
-            this.marketsLoading = this.loadMarketsHelper (data, reload, params).then ((resolved) => {
+            this.marketsLoading = this.loadMarketsHelper (coinListData, marketData, reload, params).then ((resolved) => {
                 this.reloadingMarkets = false
                 return resolved
             }, (error) => {

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -78,8 +78,7 @@ module.exports = class bitget extends Exchange {
                 'setPositionMode': false,
                 'transfer': false,
                 'withdraw': true,
-                'callCoinList': true,
-                'getCoinList': true,
+                'callMarkets': true,
             },
             'timeframes': {
                 'spot': {
@@ -1113,24 +1112,14 @@ module.exports = class bitget extends Exchange {
         return result;
     }
 
-    async callCoinList (data = undefined) {
+    async callMarkets (coinListData = undefined) {
         /**
          * @method
-         * @name bitget#callCoinList
+         * @name bitget#callMarkets
          * @description call coinList api
          * @param {object} data extra parameters specific to the bitget api endpoint
          */
-        await this.loadMarkets (data);
-    }
-
-    async getCoinList () {
-        /**
-         * @method
-         * @name bitget#getCoinList
-         * @description get coinList
-         * @returns {object} coinList data
-         */
-        return await this.loadMarkets ();
+        await this.loadMarkets (coinListData);
     }
 
     async fetchOrderBook (symbol, limit = undefined, params = {}) {

--- a/js/bitget.js
+++ b/js/bitget.js
@@ -78,7 +78,7 @@ module.exports = class bitget extends Exchange {
                 'setPositionMode': false,
                 'transfer': false,
                 'withdraw': true,
-                'callMarkets': true,
+                'callLoadMarkets': true,
             },
             'timeframes': {
                 'spot': {
@@ -1112,11 +1112,11 @@ module.exports = class bitget extends Exchange {
         return result;
     }
 
-    async callMarkets (coinListData = undefined) {
+    async callLoadMarkets (coinListData = undefined) {
         /**
          * @method
-         * @name bitget#callMarkets
-         * @description call coinList api
+         * @name bitget#callLoadMarkets
+         * @description call fetch currencies and fetch markets
          * @param {object} data extra parameters specific to the bitget api endpoint
          */
         await this.loadMarkets (coinListData);

--- a/js/gate.js
+++ b/js/gate.js
@@ -140,6 +140,7 @@ module.exports = class gate extends Exchange {
                 'signIn': false,
                 'transfer': true,
                 'withdraw': true,
+                'callMarkets': true,
             },
             'api': {
                 'public': {
@@ -5468,6 +5469,16 @@ module.exports = class gate extends Exchange {
             'datetime': this.iso8601 (timestamp),
             'info': info,
         };
+    }
+
+    async callMarkets (coinListData = undefined, marketData = undefined) {
+        /**
+         * @method
+         * @name gate#callMarkets
+         * @description call coinList api
+         * @param {object} data extra parameters specific to the gateio api endpoint
+         */
+        await this.loadMarkets (coinListData, marketData);
     }
 
     sign (path, api = [], method = 'GET', params = {}, headers = undefined, body = undefined) {

--- a/js/gate.js
+++ b/js/gate.js
@@ -5475,8 +5475,9 @@ module.exports = class gate extends Exchange {
         /**
          * @method
          * @name gate#callMarkets
-         * @description call coinList api
-         * @param {object} data extra parameters specific to the gateio api endpoint
+         * @description call fetchCurrencies and fetchMarkets api
+         * @param {coinListData} data extra parameters specific to the gateio api endpoint
+         * @param {marketData} data extra parameters specific to the gateio api endpoint
          */
         await this.loadMarkets (coinListData, marketData);
     }

--- a/js/gate.js
+++ b/js/gate.js
@@ -140,7 +140,7 @@ module.exports = class gate extends Exchange {
                 'signIn': false,
                 'transfer': true,
                 'withdraw': true,
-                'callMarkets': true,
+                'callLoadMarkets': true,
             },
             'api': {
                 'public': {
@@ -5463,10 +5463,10 @@ module.exports = class gate extends Exchange {
         };
     }
 
-    async callMarkets (coinListData = undefined, marketData = undefined) {
+    async callLoadMarkets (coinListData = undefined, marketData = undefined) {
         /**
          * @method
-         * @name gate#callMarkets
+         * @name gate#callLoadMarkets
          * @description call fetchCurrencies and fetchMarkets api
          * @param {coinListData} data extra parameters specific to the gateio api endpoint
          * @param {marketData} data extra parameters specific to the gateio api endpoint

--- a/js/gate.js
+++ b/js/gate.js
@@ -2172,7 +2172,6 @@ module.exports = class gate extends Exchange {
          * @param {object} [params] extra parameters specific to the gate api endpoint
          * @returns {object} A dictionary of [order book structures]{@link https://docs.ccxt.com/#/?id=order-book-structure} indexed by market symbols
          */
-        await this.loadMarkets ();
         const market = this.market (symbol);
         //
         //     const request = {
@@ -2284,7 +2283,6 @@ module.exports = class gate extends Exchange {
          * @param {object} [params] extra parameters specific to the gate api endpoint
          * @returns {object} a [ticker structure]{@link https://docs.ccxt.com/#/?id=ticker-structure}
          */
-        await this.loadMarkets ();
         const market = this.market (symbol);
         const [request, query] = this.prepareRequest (market, undefined, params);
         const method = this.getSupportedMapping (market['type'], {
@@ -2486,7 +2484,6 @@ module.exports = class gate extends Exchange {
          * @param {string} [params.marginMode] 'cross' or 'isolated' - marginMode for margin trading if not provided this.options['defaultMarginMode'] is used
          * @param {string} [params.symbol] margin only - unified ccxt symbol
          */
-        await this.loadMarkets ();
         const symbol = this.safeString (params, 'symbol');
         params = this.omit (params, 'symbol');
         const [type, query] = this.handleMarketTypeAndParams ('fetchBalance', undefined, params);
@@ -2973,7 +2970,6 @@ module.exports = class gate extends Exchange {
          * @param {object} [params] extra parameters specific to the binance api endpoint
          * @returns {object[]} a list of [trade structures]{@link https://docs.ccxt.com/#/?id=trade-structure}
          */
-        await this.loadMarkets ();
         this.checkRequiredSymbol ('fetchOrderTrades', symbol);
         //
         //      [
@@ -3348,7 +3344,6 @@ module.exports = class gate extends Exchange {
          */
         [tag, params] = this.handleWithdrawTagAndParams (tag, params);
         this.checkAddress (address);
-        await this.loadMarkets ();
         const currency = this.currency (code);
         const request = {
             'currency': currency['id'],
@@ -3499,7 +3494,6 @@ module.exports = class gate extends Exchange {
          * @param {int} [params.price_type] *contract only* 0 latest deal price, 1 mark price, 2 index price
          * @returns {object|undefined} [An order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
-        await this.loadMarkets ();
         const market = this.market (symbol);
         const contract = market['contract'];
         const trigger = this.safeValue (params, 'trigger');
@@ -4158,7 +4152,6 @@ module.exports = class gate extends Exchange {
          * @param {string} [params.settle] 'btc' or 'usdt' - settle currency for perpetual swap and future - market settle currency is used if symbol !== undefined, default="usdt" for swap and "btc" for future
          * @returns An [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
-        await this.loadMarkets ();
         const stop = this.safeValue2 (params, 'is_stop_order', 'stop', false);
         params = this.omit (params, ['is_stop_order', 'stop']);
         let clientOrderId = this.safeString2 (params, 'text', 'clientOrderId');
@@ -4425,7 +4418,6 @@ module.exports = class gate extends Exchange {
          * @param {bool} [params.stop] True if the order to be cancelled is a trigger order
          * @returns An [order structure]{@link https://docs.ccxt.com/#/?id=order-structure}
          */
-        await this.loadMarkets ();
         const market = (symbol === undefined) ? undefined : this.market (symbol);
         const stop = this.safeValue2 (params, 'is_stop_order', 'stop', false);
         params = this.omit (params, ['is_stop_order', 'stop']);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ango-ya/ccxt",
-  "version": "1.42.36",
+  "version": "1.50.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@ango-ya/ccxt",
-      "version": "1.42.36",
+      "version": "1.50.2",
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ango-ya/ccxt",
-  "version": "1.50.1",
+  "version": "1.50.2",
   "description": "A JavaScript / Python / PHP cryptocurrency trading library with support for 130+ exchanges",
   "main": "./ccxt.js",
   "unpkg": "dist/ccxt.browser.js",

--- a/wiki/Install.md
+++ b/wiki/Install.md
@@ -58,13 +58,13 @@ If that does not help, please, follow here: https://github.com/nodejs/node-gyp#o
 
 All-in-one browser bundle (dependencies included), served from a CDN of your choice:
 
-* jsDelivr: https://cdn.jsdelivr.net/npm/ccxt@1.50.1/dist/ccxt.browser.js
-* unpkg: https://unpkg.com/ccxt@1.50.1/dist/ccxt.browser.js
+* jsDelivr: https://cdn.jsdelivr.net/npm/ccxt@1.50.2/dist/ccxt.browser.js
+* unpkg: https://unpkg.com/ccxt@1.50.2/dist/ccxt.browser.js
 
 You can obtain a live-updated version of the bundle by removing the version number from the URL (the `@a.b.c` thing) — however, we do not recommend to do that, as it may break your app eventually. Also, please keep in mind that we are not responsible for the correct operation of those CDN servers.
 
 ```HTML
-<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/ccxt@1.50.1/dist/ccxt.browser.js"></script>
+<script type="text/javascript" src="https://cdn.jsdelivr.net/npm/ccxt@1.50.2/dist/ccxt.browser.js"></script>
 ```
 
 Creates a global `ccxt` object:


### PR DESCRIPTION
変更内容
・gate.io APIのパブリックエンドポイントはrate limit制限が200req/10sと厳しいので、ccxtでパブリックエンドポイントを叩いている関数fetchCurrenciesとfetchMarketsをできるだけ実行しないように、キャッシュデータがある場合はキャッシュデータを利用するようにした。
・bitgetでも関数名を同じものとした。

主に変更を加えたファイル
js/bitget.js
js/gate.js
js/base/Exchange.js